### PR TITLE
ci: lint sh/Dockerfiles + gverify fail-closed

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "**/Dockerfile"
       - "**/entrypoint.py"
+      - "**/entrypoint.sh"
       - "**/PLATFORMS"
       - "tests/**"
       - "tools/genmatrix.js"

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -1,0 +1,35 @@
+name: lint-docker
+
+on:
+  pull_request:
+    paths:
+      - "**/Dockerfile"
+      - ".github/workflows/lint-docker.yml"
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find Dockerfiles
+        id: find
+        run: |
+          files=$(find . -name Dockerfile -not -path './.git/*' | sort | tr '\n' ' ')
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
+          echo "Linting: ${files}"
+
+      - name: Run hadolint
+        run: |
+          docker run --rm -i hadolint/hadolint:latest hadolint - < /dev/null || true
+          rc=0
+          for f in ${{ steps.find.outputs.files }}; do
+            echo "::group::hadolint ${f}"
+            if ! docker run --rm -i hadolint/hadolint:latest hadolint - < "${f}"; then
+              rc=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "${rc}"

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -21,13 +21,17 @@ jobs:
           echo "files=${files}" >> "$GITHUB_OUTPUT"
           echo "Linting: ${files}"
 
+      - name: Pull hadolint
+        run: docker pull hadolint/hadolint:v2.12.0
+
       - name: Run hadolint
+        env:
+          FILES: ${{ steps.find.outputs.files }}
         run: |
-          docker run --rm -i hadolint/hadolint:latest hadolint - < /dev/null || true
           rc=0
-          for f in ${{ steps.find.outputs.files }}; do
+          for f in $FILES; do
             echo "::group::hadolint ${f}"
-            if ! docker run --rm -i hadolint/hadolint:latest hadolint - < "${f}"; then
+            if ! docker run --rm -i hadolint/hadolint:v2.12.0 hadolint - < "${f}"; then
               rc=1
             fi
             echo "::endgroup::"

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -1,0 +1,29 @@
+name: lint-sh
+
+on:
+  pull_request:
+    paths:
+      - "**/*.sh"
+      - ".github/workflows/lint-sh.yml"
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck
+        run: |
+          # POSIX sh dialect; entrypoints must run under dash/busybox.
+          mapfile -t files < <(find . -name '*.sh' -not -path './.git/*' | sort)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No shell scripts found."
+            exit 0
+          fi
+          printf 'Linting: %s\n' "${files[@]}"
+          shellcheck --shell=sh "${files[@]}"

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -18,6 +18,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
       - name: Run shellcheck
+        shell: bash
         run: |
           # POSIX sh dialect; entrypoints must run under dash/busybox.
           mapfile -t files < <(find . -name '*.sh' -not -path './.git/*' | sort)

--- a/1.14.5/bullseye/Dockerfile
+++ b/1.14.5/bullseye/Dockerfile
@@ -28,6 +28,7 @@ ARG DESCRIPTOR_PATH=dogecoin/contrib/gitian-descriptors/gitian-${RLS_OS}.yml
 ARG RLS_LOCATION=https://github.com/dogecoin/dogecoin/releases/download/v${RLS_VERSION}
 
 # install system requirements
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     git \
@@ -94,6 +95,7 @@ EXPOSE 22555 44555 18332
 VOLUME ["/dogecoin/.dogecoin"]
 
 # Dependencies install
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 \
     && rm -rf /var/lib/apt/lists/*

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -88,20 +88,6 @@ RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
     && tar -xf dogecoin.tar.gz --strip-components=1
 
 
-# Build rootlesskit as a fully static binary (CGO_ENABLED=0) from xanimo's fork.
-# Enables optional user-namespace-based rootless execution inside the container,
-# solving the host UID-mapping problem for bind-mounted volumes without root.
-FROM golang:1.22-alpine AS rootlesskit
-
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-
-# hadolint ignore=DL3018
-RUN apk add --no-cache git make \
-    && git clone --depth 1 https://github.com/xanimo/rootlesskit /src
-WORKDIR /src
-RUN CGO_ENABLED=0 make bin/rootlesskit
-
-
 # Build minimal Debian-based rootfs; works on all Debian-supported arches
 # including linux/386 (which ubuntu:22.04 dropped).
 FROM debian:bookworm-slim AS installer
@@ -139,9 +125,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Populate minimal /etc, create the dogecoin user's home + datadir,
-# and regenerate the dynamic-linker cache for the chiselled rootfs.
-# No setuid binary, no fixed-UID assumption beyond UID 1000:
-# operators using Docker rootless / rootlesskit get full UID remapping.
+# and regenerate the dynamic-linker cache for the assembled rootfs.
+# No setuid binary, no fixed-UID assumption beyond UID 1000: operators
+# can remap with Docker rootless mode or --user at runtime.
 RUN printf 'root:x:0:0:root:/root:/sbin/nologin\n%s:x:1000:1000::/%s:/sbin/nologin\n' \
         "${USER}" "${USER}" > /staging/etc/passwd \
     && printf 'root:x:0:\n%s:x:1000:\n' "${USER}" > /staging/etc/group \
@@ -162,12 +148,6 @@ COPY --from=verify \
     /staging/usr/local/bin/
 RUN chmod 0755 /staging/usr/local/bin/dogecoin* \
     && chown root:root /staging/usr/local/bin/dogecoin*
-
-# Include the static rootlesskit binary for operators who need user-namespace
-# UID remapping (e.g. `docker run … rootlesskit dogecoind`).
-COPY --from=rootlesskit /src/bin/rootlesskit /staging/usr/local/bin/rootlesskit
-RUN chmod 0755 /staging/usr/local/bin/rootlesskit \
-    && chown root:root /staging/usr/local/bin/rootlesskit
 
 # Install the shell entrypoint (replaces Python; no extra runtime dep).
 COPY entrypoint.sh /staging/usr/local/bin/entrypoint.sh

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -60,8 +60,8 @@ RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${RLS_ARCH}" = "" ]; then echo "Could not determine architecture" >&2; exit 1; fi \
     && RLS_FILE_NAME="dogecoin-${RLS_VERSION}-${RLS_ARCH}-${RLS_OS}-${RLS_LIB}.tar.gz" \
     && wget -q "${RLS_LOCATION}/${RLS_FILE_NAME}" \
-    && gverify_out=$(gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}") \
-    && printf '%s\n' "${gverify_out}" | grep OK | sed s/:.*// | sort -u > ok_signers.txt || true \
+    && gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}" \
+       | grep OK | sed s/:.*// | sort -u > ok_signers.txt || true \
     && TRUSTED_SIGNER="" \
     && while read -r signer; do \
          [ -z "${signer}" ] && continue; \

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -47,7 +47,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN git clone --depth 1 "${REPO_GITIAN_BUILDER}" gitian \
     && git clone --depth 1 "${REPO_GITIAN_SIGS}" sigs \
     && git clone --depth 1 -b "v${RLS_VERSION}" "${REPO_DOGECOIN_CORE}" dogecoin \
-    && find dogecoin/contrib/gitian-keys -name "*.pgp" -print0 | xargs -0 -n 1 gpg --import
+    && find dogecoin/contrib/gitian-keys -name "*.pgp" -print0 | xargs -0 -n 1 gpg --import \
+    && wget -qO- https://github.com/KunNw0n.gpg | gpg --import \
+    && gpg --list-keys 7E453C9D37AC2EB246645C4B75055E4030051C37
 
 # determine architecture, download release binary, then verify it against a
 # trusted gitian signer (fail-closed unless ALLOW_UNTRUSTED_SIGNERS=1) and

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -26,6 +26,13 @@ ARG SIG_PATH=${RLS_VERSION}-${RLS_OS}
 ARG DESCRIPTOR_PATH=dogecoin/contrib/gitian-descriptors/gitian-${RLS_OS}.yml
 ARG RLS_LOCATION=https://github.com/dogecoin/dogecoin/releases/download/v${RLS_VERSION}
 
+# Signature policy. By default the build FAILS if gverify finds no signer in
+# the imported keyring whose assert matches the downloaded binary. Releases
+# whose signers are not yet in contrib/gitian-keys can be built by setting
+# ALLOW_UNTRUSTED_SIGNERS=1, which downgrades the missing-signer case to a
+# warning. The pinned SHA256 check below is ALWAYS enforced regardless.
+ARG ALLOW_UNTRUSTED_SIGNERS=0
+
 # install system requirements
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -42,8 +49,9 @@ RUN git clone --depth 1 "${REPO_GITIAN_BUILDER}" gitian \
     && git clone --depth 1 -b "v${RLS_VERSION}" "${REPO_DOGECOIN_CORE}" dogecoin \
     && find dogecoin/contrib/gitian-keys -name "*.pgp" -print0 | xargs -0 -n 1 gpg --import
 
-# determine architecture, download release binary and verify against a
-# random OK signer and against pinned sha256sums
+# determine architecture, download release binary, then verify it against a
+# trusted gitian signer (fail-closed unless ALLOW_UNTRUSTED_SIGNERS=1) and
+# against the pinned sha256sums above
 RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${ARCHITECTURE}" = "amd64" ]; then RLS_ARCH=x86_64;    fi \
     && if [ "${ARCHITECTURE}" = "arm64" ]; then RLS_ARCH=aarch64;   fi \
@@ -52,10 +60,26 @@ RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${RLS_ARCH}" = "" ]; then echo "Could not determine architecture" >&2; exit 1; fi \
     && RLS_FILE_NAME="dogecoin-${RLS_VERSION}-${RLS_ARCH}-${RLS_OS}-${RLS_LIB}.tar.gz" \
     && wget -q "${RLS_LOCATION}/${RLS_FILE_NAME}" \
-    && { gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}" || true; } \
-       | { grep OK || true; } | shuf -n 1 | sed s/:.*// > random_signer.txt \
-    && if [ -s random_signer.txt ]; then \
-         grep "${RLS_FILE_NAME}" "sigs/${SIG_PATH}/$(cat random_signer.txt)/"*assert | sha256sum -c; \
+    && gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}" \
+       | grep OK | sed s/:.*// | sort -u > ok_signers.txt || true \
+    && TRUSTED_SIGNER="" \
+    && while read -r signer; do \
+         [ -z "${signer}" ] && continue; \
+         if grep -lq "${RLS_FILE_NAME}" "sigs/${SIG_PATH}/${signer}/"*assert 2>/dev/null; then \
+           TRUSTED_SIGNER="${signer}"; break; \
+         fi; \
+       done < ok_signers.txt \
+    && if [ -n "${TRUSTED_SIGNER}" ]; then \
+         echo "Verifying against trusted signer: ${TRUSTED_SIGNER}"; \
+         grep "${RLS_FILE_NAME}" "sigs/${SIG_PATH}/${TRUSTED_SIGNER}/"*assert | sha256sum -c; \
+       elif [ "${ALLOW_UNTRUSTED_SIGNERS}" = "1" ]; then \
+         echo "WARNING: no trusted signer for ${RLS_FILE_NAME} in keyring;" >&2; \
+         echo "WARNING: proceeding on pinned SHA256 only (ALLOW_UNTRUSTED_SIGNERS=1)." >&2; \
+       else \
+         echo "ERROR: no trusted gitian signer found for ${RLS_FILE_NAME}." >&2; \
+         echo "ERROR: import the release signer's key or set" >&2; \
+         echo "ERROR: --build-arg ALLOW_UNTRUSTED_SIGNERS=1 to override." >&2; \
+         exit 1; \
        fi \
     && grep "${RLS_FILE_NAME}" SHASUMS | sha256sum -c \
     && mv "${RLS_FILE_NAME}" dogecoin.tar.gz \

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -150,6 +150,7 @@ RUN printf 'root:x:0:0:root:/root:/sbin/nologin\n%s:x:1000:1000::/%s:/sbin/nolog
     && chown -R 1000:1000 "/staging/${USER}" \
     && printf 'include /etc/ld.so.conf.d/*.conf\n/lib\n/usr/lib\n' \
         > /staging/etc/ld.so.conf \
+    && if [ -d /usr/lib64 ]; then cp -a /usr/lib64 /staging/usr/; fi \
     && ldconfig -r /staging
 
 # Install dogecoin binaries: owned by root, world-executable, no setuid bit.

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -102,45 +102,41 @@ WORKDIR /src
 RUN CGO_ENABLED=0 make bin/rootlesskit
 
 
-# Use the chisel binary from xanimo's fork to carve a minimal Ubuntu 22.04
-# rootfs into /staging, then populate it with the dogecoin binaries.
-FROM ubuntu:22.04 AS installer
+# Build minimal Debian-based rootfs; works on all Debian-supported arches
+# including linux/386 (which ubuntu:22.04 dropped).
+FROM debian:bookworm-slim AS installer
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=xanimo/chisel:latest /usr/bin/chisel /usr/bin/chisel
-
 ARG USER=dogecoin
-
-# ca-certificates is required by the chisel binary to verify GitHub TLS
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /staging
 
-# Cut only what dogecoind needs at runtime:
-#   base-files_base       - directory skeleton (/etc, /tmp, /var, …)
-#   base-files_release-info - /etc/os-release
-#   libc6_libs            - glibc + dynamic linker
-#   libc6_config          - /etc/ld.so.conf.d for library discovery
-#   libgcc-s1_libs        - GCC unwinding runtime
-#   libstdc++6_libs       - C++ standard library
-#   dash_bins             - /bin/sh for the shell entrypoint
-#   coreutils_mkdir       - /bin/mkdir for datadir creation
-#   grep_bins             - /bin/grep for entrypoint option parsing
-#   sed_bins              - /bin/sed for entrypoint option parsing
-RUN chisel cut --release ubuntu-22.04 --root /staging \
-    base-files_base \
-    base-files_release-info \
-    libc6_libs \
-    libc6_config \
-    libgcc-s1_libs \
-    libstdc++6_libs \
-    dash_bins \
-    coreutils_mkdir \
-    grep_bins \
-    sed_bins
+# Install libstdc++6 (not in bookworm-slim), then copy exactly the files
+# owned by each needed runtime package into /staging. Explicit package list
+# avoids pulling in dpkg/tar/etc. via recursive dep resolution.
+# cp -a preserves symlinks and arch-specific library paths.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libstdc++6 \
+    && for pkg in \
+         base-files \
+         libc6 libgcc-s1 libstdc++6 \
+         dash grep sed coreutils \
+         libpcre2-8-0 libacl1 libattr1 libselinux1 libsigsegv2 libgmp10; \
+       do \
+         dpkg -L "$pkg" 2>/dev/null | grep -v '^\.$' \
+           | while IFS= read -r f; do \
+               if [ -d "$f" ] && [ ! -L "$f" ]; then \
+                 mkdir -p "/staging$f"; \
+               elif [ -e "$f" ]; then \
+                 mkdir -p "/staging$(dirname "$f")"; \
+                 cp -a "$f" "/staging$f"; \
+               fi; \
+             done; \
+       done \
+    && ln -sf dash /staging/usr/bin/sh \
+    && rm -rf /var/lib/apt/lists/*
 
 # Populate minimal /etc, create the dogecoin user's home + datadir,
 # and regenerate the dynamic-linker cache for the chiselled rootfs.

--- a/1.14.9/bookworm/Dockerfile
+++ b/1.14.9/bookworm/Dockerfile
@@ -60,8 +60,8 @@ RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${RLS_ARCH}" = "" ]; then echo "Could not determine architecture" >&2; exit 1; fi \
     && RLS_FILE_NAME="dogecoin-${RLS_VERSION}-${RLS_ARCH}-${RLS_OS}-${RLS_LIB}.tar.gz" \
     && wget -q "${RLS_LOCATION}/${RLS_FILE_NAME}" \
-    && gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}" \
-       | grep OK | sed s/:.*// | sort -u > ok_signers.txt || true \
+    && gverify_out=$(gitian/bin/gverify --no-markup -d sigs -r "${SIG_PATH}" "${DESCRIPTOR_PATH}") \
+    && printf '%s\n' "${gverify_out}" | grep OK | sed s/:.*// | sort -u > ok_signers.txt || true \
     && TRUSTED_SIGNER="" \
     && while read -r signer; do \
          [ -z "${signer}" ] && continue; \

--- a/1.14.9/bookworm/README.md
+++ b/1.14.9/bookworm/README.md
@@ -1,0 +1,71 @@
+# Dogecoin Core 1.14.9 — minimal hardened image
+
+A `FROM scratch` image containing only the verified Dogecoin Core binaries, a
+minimal glibc userland, and a POSIX `sh` entrypoint. No OS layer, no package
+manager, no root user at runtime.
+
+## Security properties
+
+The image is built to run fully unprivileged:
+
+- Runs as `USER 1000:1000` (the `dogecoin` user); root is never used at runtime.
+- No setuid or setgid binaries.
+- Binaries and the entrypoint are owned by `root` and are not writable by the
+  runtime user — a compromised process cannot overwrite them.
+- No package manager, no `su`/`sudo`, and `dash` is the only shell.
+- Final stage is `scratch`: only libc/libgcc/libstdc++, a handful of coreutils
+  (`mkdir`, `grep`, `sed`), `dash`, and the three Dogecoin binaries are present.
+
+These properties concern the **in-image** surface. They remove in-image
+privilege-escalation primitives; they do not by themselves prevent container
+escape, which depends on the container runtime, host kernel, and the flags
+passed to `docker run`. Run with the restrictions below for a hardened
+deployment.
+
+## Recommended hardened invocation
+
+The image runs cleanly with all capabilities dropped, `no-new-privileges`, and
+a read-only root filesystem. When using `--read-only`, the data directory must
+be a writable mount owned by UID 1000 — a bare `--tmpfs` defaults to root
+ownership, so pass `uid=1000,gid=1000`:
+
+```sh
+docker run -d --name dogecoin \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --read-only \
+  --tmpfs /dogecoin/.dogecoin:uid=1000,gid=1000 \
+  -p 22556:22556 \
+  <image> dogecoind -printtoconsole
+```
+
+For a persistent chain, replace the `--tmpfs` with a named volume or a
+bind-mount whose host directory is owned by UID 1000:
+
+```sh
+docker run -d --name dogecoin \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --read-only \
+  -v dogecoin-data:/dogecoin/.dogecoin \
+  -p 22556:22556 \
+  <image> dogecoind -printtoconsole
+```
+
+> If the data directory is root-owned, `dogecoind` fails at startup with
+> `boost::filesystem::create_directory: Permission denied`. This is a mount
+> ownership issue, not an image fault: ensure the mount is writable by
+> UID 1000.
+
+## Host UID remapping
+
+The image does not bundle any privilege-remapping helper. For bind-mounted
+volumes where host file ownership matters, use Docker rootless mode, the
+daemon's `--userns-remap`, or pass `--user "$(id -u):$(id -g)"` at runtime.
+
+## Environment variables
+
+Any `dogecoind`/`dogecoin-cli`/`dogecoin-tx` option can be supplied as an
+environment variable: uppercase the option name and replace `-` with `_`. For
+example, `-rpcuser` becomes `RPCUSER` and `-help-debug` becomes `HELP_DEBUG`.
+The entrypoint converts set variables into CLI flags at startup.

--- a/1.14.9/bookworm/entrypoint.sh
+++ b/1.14.9/bookworm/entrypoint.sh
@@ -44,6 +44,7 @@ while IFS= read -r line; do
     var=$(printf '%s' "$opt" | sed 'y/abcdefghijklmnopqrstuvwxyz-/ABCDEFGHIJKLMNOPQRSTUVWXYZ_/')
     # POSIX: ${VAR+y} expands to "y" if VAR is set (even when empty).
     eval "isset=\${${var}+y}"
+    # shellcheck disable=SC2154  # isset is assigned via the eval above
     [ "$isset" != "y" ] && continue
     eval "val=\${${var}}"
     unset "$var" 2>/dev/null || true

--- a/1.14.9/bookworm/entrypoint.sh
+++ b/1.14.9/bookworm/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Entrypoint for Dogecoin Core — runs as dogecoin user (UID 1000), no root.
-# For host UID remapping with bind-mounted volumes, wrap with rootlesskit:
-#   docker run … rootlesskit dogecoind
+# For host UID remapping with bind-mounted volumes, use Docker rootless mode
+# or pass --user "$(id -u):$(id -g)" at runtime.
 set -e
 
 EXECUTABLES="dogecoind dogecoin-cli dogecoin-tx"
@@ -13,7 +13,7 @@ fi
 
 EXECUTABLE="$1"; shift
 
-# Pass arbitrary commands through directly (e.g. sh, dogecoin-cli, rootlesskit).
+# Pass arbitrary commands through directly (e.g. sh, dogecoin-cli, dogecoin-tx).
 case " $EXECUTABLES " in
     *" $EXECUTABLE "*) ;;
     *) exec "$EXECUTABLE" "$@" ;;


### PR DESCRIPTION
- **ci: lint sh entrypoints and Dockerfiles, build on entrypoint.sh**
- **fix: fail closed when no trusted gitian signer (1.14.9/bookworm)**
